### PR TITLE
ログイン時のエラーメッセージを追加

### DIFF
--- a/src/routes/signin/route.lazy.tsx
+++ b/src/routes/signin/route.lazy.tsx
@@ -28,10 +28,18 @@ function SignIn () {
   });
 
   const onSubmit = async (data: SignInProps) => {
-    await postSignDataMutation.mutateAsync(data)
-    navigate({
-      to: "/"
-    })
+    try {
+      await postSignDataMutation.mutateAsync(data);
+      navigate({
+        to: "/",
+      });
+    } catch (error: any) {
+      if (error.response.status === 401) {
+        window.alert("ログイン情報が正しくありません。再度お試しください。");
+      } else {
+        window.alert("エラーが発生しました。時間をおいて試してみてください");
+      }
+    }
   };
 
   return (

--- a/test/SignIn.test.tsx
+++ b/test/SignIn.test.tsx
@@ -1,5 +1,13 @@
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterEach,
+  afterAll,
+} from "vitest";
 import { render, cleanup, screen } from "@testing-library/react";
 import SignIn from "../src/routes/signin/route.lazy";
 import {
@@ -10,10 +18,22 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
 import userEvent from "@testing-library/user-event";
 
+const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+
+beforeAll(() => {
+  server.listen();
+});
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
+});
+afterAll(() => {
+  server.close();
 });
 
 const queryClient = new QueryClient({
@@ -23,6 +43,48 @@ const queryClient = new QueryClient({
       gcTime: 0,
     },
   },
+});
+
+export const handlers = [
+  // Intercept "GET https://example.com/user" requests...
+  http.get("http://localhost:3000/v1/auth/sign_in", () => {
+    return HttpResponse.json(
+      {
+        data: {
+          email: "bbbb@gmail.com",
+          provider: "email",
+          uid: "bbbb@gmail.com",
+          id: 2,
+          allow_password_change: false,
+          name: "テストユーザー",
+          nickname: null,
+          image: null,
+        },
+      },
+      { status: 200 }
+    );
+  }),
+  http.get("http://localhost:3000/v1/users/current_user_info.json", () => {
+    return HttpResponse.json(
+      {
+        is_login: false,
+      },
+      { status: 200 }
+    );
+  }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+  server.listen();
+});
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
+afterAll(() => {
+  server.close();
 });
 
 describe("SignIn Component", () => {
@@ -90,5 +152,79 @@ describe("SignIn Component", () => {
     expect(
       screen.getByText("パスワードは6文字以上入力して下さい")
     ).toBeTruthy();
+  });
+
+  it("An alert should appear when a 401 error is returned", async () => {
+    const rootRoute = createRootRoute();
+    const SignInRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/signin",
+      component: () => <SignIn />,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([SignInRoute]),
+      history: createMemoryHistory({ initialEntries: ["/signin"] }),
+    });
+
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+    server.use(
+      http.post("http://localhost:3000/v1/auth/sign_in", () => {
+        return new HttpResponse(null, { status: 401 });
+      })
+    );
+
+    await screen.findByText("ログインフォーム");
+    const emailInput = screen.getByPlaceholderText("emailを入力してください");
+    const passwordInput =
+      screen.getByPlaceholderText("passwordを入力してください");
+
+    await userEvent.type(emailInput, "UnregisteredUser@gmail.com");
+    await userEvent.type(passwordInput, "password");
+    await userEvent.click(screen.getByText("送信する"));
+
+    expect(alertMock).toHaveBeenCalledWith(
+      "ログイン情報が正しくありません。再度お試しください。"
+    );
+  });
+
+  it("An alert should appear when a 500 error is returned", async () => {
+    const rootRoute = createRootRoute();
+    const SignInRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/signin",
+      component: () => <SignIn />,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([SignInRoute]),
+      history: createMemoryHistory({ initialEntries: ["/signin"] }),
+    });
+
+    const rendered = render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+    server.use(
+      http.post("http://localhost:3000/v1/auth/sign_in", () => {
+        return new HttpResponse(null, { status: 500 });
+      })
+    );
+
+    await screen.findByText("ログインフォーム");
+    const emailInput = screen.getByPlaceholderText("emailを入力してください");
+    const passwordInput =
+      screen.getByPlaceholderText("passwordを入力してください");
+
+    await userEvent.type(emailInput, "UnregisteredUser@gmail.com");
+    await userEvent.type(passwordInput, "password");
+    await userEvent.click(screen.getByText("送信する"));
+
+    expect(alertMock).toHaveBeenCalledWith(
+      "エラーが発生しました。時間をおいて試してみてください"
+    );
   });
 });


### PR DESCRIPTION
エラーメッセージの表示
レスポンスのステータスコードが401の場合、一致するユーザーがいない旨をアラートで表示します。
その他のステータスコード（例：500エラー）が返された場合には、時間をおいて再試行するように促すメッセージを表示します。

テストの追加
上記のエラーメッセージ表示機能に関するテストを追加しました。テストでは、エラーメッセージが正しく表示されることを確認します。