### PR TITLE
フォロー解除を行う際の引数の変更と未使用インポートの削除

### DIFF
--- a/src/routes/$recipeId/index.tsx
+++ b/src/routes/$recipeId/index.tsx
@@ -149,7 +149,7 @@ function SinglePost() {
              <button
                onClick={(e) => {
                  e.preventDefault();
-                 unfollowMutation.mutate(recipe?.follow_id as string);
+                 unfollowMutation.mutate(recipe?.user_id as string);
                  refetch();
                }}
                style={{ opacity: unfollowMutation.isPending ? 0.2 : 1 }}

--- a/src/routes/myfollowings/index.lazy.tsx
+++ b/src/routes/myfollowings/index.lazy.tsx
@@ -3,7 +3,6 @@ import styles from "../../styles/Follow.module.css";
 import { FollowingsList } from "../../components/UserList/FollowingsList";
 import {
   useFetchFollowings,
-  useCancelFollowing,
   useFetchAuthInfo,
 } from "../../hooks/useQueryHooks";
 
@@ -14,7 +13,7 @@ export const Route = createLazyFileRoute("/myfollowings/")({
 function Followings() {
   const { data: followings } = useFetchFollowings();
   const { data: myUser } = useFetchAuthInfo();
-  
+
   return (
     <div className={styles.wrapper}>
       <h2>フォロー中</h2>


### PR DESCRIPTION
1. フォローを解除する際に、followed_idを渡すことで解除するように変更
2. 使っていなかった関数のimportを取り消しました