### PR TITLE
change: 画像の最大ファイルサイズの引き下げ

### DIFF
--- a/src/routes/$recipeId/edit.lazy.tsx
+++ b/src/routes/$recipeId/edit.lazy.tsx
@@ -75,7 +75,7 @@ export function Index() {
     if (files && files[0]) {
       const file = files[0];
       const options = {
-        maxSizeMB: 3,
+        maxSizeMB: 0.3,
         maxWidthOrHeight: 1000,
       };
 

--- a/src/routes/create/route.lazy.tsx
+++ b/src/routes/create/route.lazy.tsx
@@ -61,7 +61,7 @@ export function Create() {
     if (files && files[0]) {
       const file = files[0];
       const options = {
-        maxSizeMB: 3,
+        maxSizeMB: 0.3,
         maxWidthOrHeight: 1000,
       };
 


### PR DESCRIPTION
現状の画像の最大ファイルサイズは3MBだと、レシピ一覧を表示する際に時間がかかってしまうため、レシピ一覧画面が早く表示されるように、画像の最大ファイルサイズを0.3MBに引き下げました